### PR TITLE
added charsets for [vVhHR]

### DIFF
--- a/resources/com/gfredericks/test/chuck/regex.bnf
+++ b/resources/com/gfredericks/test/chuck/regex.bnf
@@ -59,7 +59,7 @@ BCCDash = '-'
 
 (** BASE CHARACTER STUFFS **)
 
-EscapedChar = OctalChar | HexChar | BasicEscapedChar | NormalSlashedCharacters | ControlChar | WhatDoesThisMean
+EscapedChar = OctalChar | HexChar | BasicEscapedChar | NormalSlashedCharacters | ControlChar
 OctalChar = <'\\0'> (OctalDigits1 | OctalDigits2 | OctalDigits3)
 OctalDigits1 = #"[0-7]" ! #"[0-7]"
 OctalDigits2 = (#"[0-3][0-7]" ! #"[0-7]") | #"[4-7][0-7]"
@@ -71,12 +71,11 @@ LongHexChar = <'\\x{'> #'[0-9a-fA-F]+' <'}'>
 BasicEscapedChar = <'\\'> #"[^a-zA-Z0-9]"
 
 (* probably missing something here *)
-SpecialCharClass = <'\\'> #"[wWsSdD]"
+SpecialCharClass = <'\\'> #"[wWsSdDvVhHR]"
 (* Gotta figure out what these mean *)
 UnicodeCharacterClass = <'\\'> #'[pP]' (#"[CLMNPSZ]" | #"\{[a-zA-Z]+\}")
 
 NormalSlashedCharacters = #"\\[tnrfae]"
-WhatDoesThisMean = '\\v'
 
 (* why did I think you could have a backslashed character here?? *)
 ControlChar = <'\\c'> #"(?s)."

--- a/src/com/gfredericks/test/chuck/regexes.clj
+++ b/src/com/gfredericks/test/chuck/regexes.clj
@@ -342,7 +342,12 @@
   (if-let [type (:simple-class m)]
     (case type
       :dot charsets/all-unicode-but-line-terminators
-      (\d \D \s \S \w \W) (charsets/predefined-regex-classes type))
+      (\d \D \s \S \w \W \v \V \h \H \R) (charsets/predefined-regex-classes type)
+      ;; unsupported
+      (throw (ex-info (str "Unsupported charset: " type)
+                      {:type ::unsupported-charset
+                       :charset type
+                       :patches? "welcome."})))
     (-> m :elements first! compile-class)))
 
 (defmethod compile-class :class-intersection

--- a/src/com/gfredericks/test/chuck/regexes/charsets.clj
+++ b/src/com/gfredericks/test/chuck/regexes/charsets.clj
@@ -167,9 +167,18 @@
 (def predefined-regex-classes
   (let [d (range "0" "9")
         s (reduce union (map singleton [" " "\t" "\n" "\u000B" "\f" "\r"]))
+        v (reduce union (map singleton ["\n" "\u000B" "\f" "\r" "\u0085" "\u2028"
+                                        "\u2029"]))
+        h (union (range "\u2000" "\u200a")
+                 (reduce union (map singleton [" " "\t" "\u00A0" "\u1680" "\u180e" "\u202f"
+                                               "\u205f" "\u3000"])))
+        R (reduce union (map singleton ["\u000D\u000A" "\u000A" "\u000B" "\u000C"
+                                        "\u000D" "\u0085" "\u2028" "\u2029"]))
         w (union d (union (range "a" "z")
                           (range "A" "Z")))]
-    {\d d, \s s, \w w
+    {\d d, \s s, \w w, \v v, \R R
+     \V (difference all-unicode v)
+     \H (difference all-unicode h)
      \D (difference all-unicode d)
      \S (difference all-unicode s)
      \W (difference all-unicode w)}))


### PR DESCRIPTION
I was getting some errors when running the tests so I added a few additional charsets as defined in the Java Doc:
http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html

These additions eliminated the errors for me.  I'm not entirely sure about all the unicode chars, but I think they're correct.
