### PR TITLE
Filtering out generated symbols

### DIFF
--- a/src/com/gfredericks/test/chuck/properties.clj
+++ b/src/com/gfredericks/test/chuck/properties.clj
@@ -13,12 +13,17 @@
 ;; property
 ;;
 
+(defn ^:private probably-gen-sym? [sym]
+  (let [s (name sym)]
+    (or (.startsWith s "vec__")
+        (.startsWith s "map__"))))
+
 (defn ^:private for-bindings-in-binding-expr
   [expr]
-  ;; this'll get gensyms o_O
   (->> (clojure.core/destructure [expr :dummy])
        (partition 2)
-       (map first)))
+       (map first)
+       (filter (complement probably-gen-sym?))))
 
 (defn ^:private for-bindings-in-clause
   [left right]

--- a/test/com/gfredericks/test/chuck/properties_test.clj
+++ b/test/com/gfredericks/test/chuck/properties_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [clojure.test.check :as t.c]
             [clojure.test.check.generators :as gen]
+            [clojure.test.check.clojure-test :refer [defspec]]
             [com.gfredericks.test.chuck.properties :as prop']))
 
 (deftest it-handles-exceptions-correctly
@@ -19,3 +20,7 @@
     (let [[m] fail]
       (is (= ['x] (keys m)))
       (is (<= 0 (get m 'x) 10)))))
+
+(defspec for-all-destructured-args-work-correctly 10
+  (prop'/for-all [[a b] (gen/tuple gen/int gen/int)]
+                 (+ a b)))


### PR DESCRIPTION
When trying to generate code to destructure the results of generators
with for-all, the macro was getting caught up by gen-syms. By filtering
out symbols with the prefixes "map__" and "vec__", the macro no longer
tries to generate code that references the generated symbols and works
as expected (or at least how I expected it to work). A simple test was
added as well.