### PR TITLE
add basic assertions to clojure test integration

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.clj
+++ b/src/com/gfredericks/test/chuck/clojure_test.clj
@@ -41,6 +41,9 @@
 
   For more details on this code, see http://blog.colinwilliams.name/blog/2015/01/26/alternative-clojure-dot-test-integration-with-test-dot-check/"
   [name tests bindings & body]
+  (assert (string? name) "name should be a string")
+  (assert (vector? bindings) "bindings should be a vector")
+  (assert (seq body) "body shouldn't be empty - it means you aren't testing anything")
   `(testing ~name
      (let [final-reports# (atom [])]
        (report-when-failing (tc/quick-check ~tests


### PR DESCRIPTION
because the clojure.test integration uses varargs in a macro, it's
pretty easy to forget an argument and get a weird error message out like
this:

<CompilerException java.lang.IllegalArgumentException: Don't know how
to create ISeq from: clojure.lang.Symbol,
compiling:(yeller/unit/deploys_test.clj:27:3)>

Better to just assert on the arguments and spit out detailed errors.
