### PR TITLE
Bump instaparse version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [instaparse "1.3.5"]]
+                 [instaparse "1.3.6"]]
   :deploy-repositories [["releases" :clojars]]
   :profiles {:dev {:dependencies
                    [[org.clojure/test.check "0.7.0"]]}}


### PR DESCRIPTION
Instaparse 1.3.5 is not compatible with Clojure 1.7 (starting from alpha6)