### PR TITLE
Refactor exception detection test

### DIFF
--- a/test/com/gfredericks/test/chuck/clojure_test_test.clj
+++ b/test/com/gfredericks/test/chuck/clojure_test_test.clj
@@ -31,9 +31,11 @@
   (let [test-results
         (binding [clojure.test/*test-out* (java.io.StringWriter.)]
           (clojure.test/run-tests (the-ns 'fake.test.namespace)))]
-    ;; should this be reported as an error for sure?
-    (is (= 1 (+ (:error test-results)
-                (:fail test-results)))))
+    ;; should be reported as an error, but it's being reported as :fail :/
+    (is (= {:pass 0
+            :fail 1
+            :error 0}
+           (select-keys test-results [:pass :fail :error]))))
   (remove-ns 'fake.test.namespace))
 
 (deftest for-all-test

--- a/test/com/gfredericks/test/chuck/clojure_test_test.clj
+++ b/test/com/gfredericks/test/chuck/clojure_test_test.clj
@@ -18,26 +18,6 @@
       (swap! c inc)
       (is (> @c 0)))))
 
-(deftest this-test-should-crash
-  (checking "you can divide four by numbers" 100 [i gen/pos-int]
-    ;; going for uncaught-error-not-in-assertion here
-    (let [n (/ 4 i)]
-      (is n))))
-
-(deftest exception-detection-test
-  (let [test-results
-        (binding [; need to keep the failure of this-is-supposed-to-fail from
-                  ; affecting the clojure.test.check test run
-                  *report-counters* (ref *initial-report-counters*)
-                  *test-out* (java.io.StringWriter.)]
-          (test-var #'this-test-should-crash)
-          @*report-counters*)]
-    ;; should be reported as an error, but it's being reported as :fail :/
-    (is (= {:pass 0
-            :fail 1
-            :error 0}
-           (select-keys test-results [:pass :fail :error])))))
-
 (deftest for-all-test
   (let [passing-prop (for-all [x gen/s-pos-int]
                        (is (< x (+ x x))))]
@@ -49,9 +29,3 @@
                        (is (zero? x))
                        (is (= x x)))]
     (is (not (:result (quick-check 20 failing-prop))))))
-
-(defn test-ns-hook []
-  (test-vars [#'for-all-test
-              #'counter
-              #'integer-facts
-              #'exception-detection-test]))

--- a/test/com/gfredericks/test/chuck/exception_handling_test.clj
+++ b/test/com/gfredericks/test/chuck/exception_handling_test.clj
@@ -1,0 +1,27 @@
+(ns com.gfredericks.test.chuck.exception-handling-test
+  (:require [clojure.test :refer :all]
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]]))
+
+(deftest this-test-should-crash
+  (checking "you can divide four by numbers" 100 [i gen/pos-int]
+    ;; going for uncaught-error-not-in-assertion here
+    (let [n (/ 4 i)]
+      (is n))))
+
+(deftest exception-detection-test
+  (let [test-results
+        (binding [; need to keep the failure of this-is-supposed-to-fail from
+                  ; affecting the clojure.test.check test run
+                  *report-counters* (ref *initial-report-counters*)
+                  *test-out* (java.io.StringWriter.)]
+          (test-var #'this-test-should-crash)
+          @*report-counters*)]
+    ;; should be reported as an error, but it's being reported as :fail :/
+    (is (= {:pass 0
+            :fail 1
+            :error 0}
+           (select-keys test-results [:pass :fail :error])))))
+
+(defn test-ns-hook []
+  (test-var #'exception-detection-test))


### PR DESCRIPTION
Make it easier to understand and debug. Leave it better prepared for migration to cljs using cljc by not using `eval` which is not available in the cljs runtime