### PR TITLE
Rename gen-datetime to datetime

### DIFF
--- a/src/com/gfredericks/test/chuck/generators.clj
+++ b/src/com/gfredericks/test/chuck/generators.clj
@@ -261,7 +261,7 @@
 
 (def ^:private yr-2000 (ct/date-time 2000))
 
-(defn gen-datetime
+(defn datetime
   "Generates datetime within given range and format.
 
    base-datetime => By default it'll calculate the dates from year 2000.
@@ -282,16 +282,16 @@
 
    For example If you would like to generate datetime
    from last 10 months to next 10 months:
-   (gen/sample (gen-datetime {:offset-fns [clj-time.core/months]
-                              :offset-min -10
-                              :offset-max 10}))
+   (gen/sample (datetime {:offset-fns [clj-time.core/months]
+                          :offset-min -10
+                          :offset-max 10}))
    =>
    (#<DateTime 1999-11-01T00:00:00.000Z>
     #<DateTime 1999-12-01T00:00:00.000Z>
     #<DateTime 2000-05-01T00:00:00.000Z>
     ....)"
   ([]
-   (gen-datetime {}))
+   (datetime {}))
   ([{:keys [base-datetime offset-fns offset-min offset-max]
      :or {offset-fns valid-offset-fns
           offset-min -1000

--- a/test/com/gfredericks/test/chuck/generators_test.clj
+++ b/test/com/gfredericks/test/chuck/generators_test.clj
@@ -111,10 +111,10 @@
                 %)
             sm)))
 
-(defspec gen-datetime-spec 100000
-  (prop/for-all [dt (gen'/gen-datetime {:offset-min 0
-                                        :offset-max 100
-                                        :offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months]})]
+(defspec datetime-spec 100000
+  (prop/for-all [dt (gen'/datetime {:offset-min 0
+                                    :offset-max 100
+                                    :offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months]})]
                 (ct/within? (ct/date-time 2000)
                             (ct/date-time 2009)
                             dt)))


### PR DESCRIPTION
Move implementation details to test.chuck.datetimes ns

Uses gen/choose instead of gen'/bounded-int in gen-datetime, to avoid a circular dependency

Fixes #19