### PR TITLE
Set jvm-opts so build can run in circleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - lein with-profile +circle-ci test

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
                  [instaparse "1.3.6"]]
   :deploy-repositories [["releases" :clojars]]
   :profiles {:dev {:dependencies
-                   [[org.clojure/test.check "0.7.0"]]}}
+                   [[org.clojure/test.check "0.7.0"]]}
+             :circle-ci {:jvm-opts ["-Xmx1g" "-server"]}}
   :aliases {"test-all"
             ^{:doc "Runs tests on multiple JVMs; profiles java-7
                     and java-8 should be defined outside this project."}


### PR DESCRIPTION
Without this the build fails because it hits the 4GB mem limit