### PR TITLE
Fix missing output from tests

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -12,7 +12,12 @@
                   value)))
 
 (defn report-exception [result]
-  (is (not-exception? (:result result)) result))
+  (if (:result result)
+    (is (not-exception? (:result result)) result)
+    (do
+      (newline)
+      #?(:clj  (ct/with-test-out (println result))
+         :cljs (println result)))))
 
 (defn pass? [reports]
   (every? #(= (:type %) :pass) reports))

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -1,14 +1,15 @@
 (ns com.gfredericks.test.chuck.clojure-test-output-test
-  (:require #?(:clj  [clojure.test :refer :all])
-            #?(:cljs [cljs.test :refer-macros [deftest is]])
+  (:require #?(:clj  [clojure.test :refer :all]
+               :cljs [cljs.test :refer [test-vars] :refer-macros [deftest is]])
+            #?(:cljs [cljs.reader :refer [read-string]])
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
-            [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking for-all]]))
+            [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking]]))
 
 (deftest a-failing-test
   (checking "all ints lt 5" 100
-             [i gen/int]
-             (is (< i 5))))
+    [i gen/int]
+    (is (< i 5))))
 
 (deftest failure-output-test
   (let [[test-results out] (capture-report-counters-and-out #'a-failing-test)]

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -1,0 +1,25 @@
+(ns com.gfredericks.test.chuck.clojure-test-output-test
+  (:require #?(:clj  [clojure.test :refer :all])
+            #?(:cljs [cljs.test :refer-macros [deftest is]])
+            [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
+            [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking for-all]]))
+
+(deftest a-failing-test
+  (checking "all ints lt 5" 100
+             [i gen/int]
+             (is (< i 5))))
+
+(deftest failure-output-test
+  (let [[test-results out] (capture-report-counters-and-out #'a-failing-test)]
+    (is (re-find #"expected: \(< i 5\)" out))
+    (is (re-find #"actual: \(not \(< \d 5\)" out))
+    (is (re-find #"\{.*:result false.*\}" out))
+    (let [tc-report (second (re-find #"(\{:result false.*\})" out))]
+      (is tc-report)
+      (when-let [tc-report (and tc-report (read-string tc-report))]
+        (is (not (:result tc-report)))
+        (is (= [5] (get-in tc-report [:shrunk :smallest])))))))
+
+(defn test-ns-hook []
+  (test-vars [#'failure-output-test]))

--- a/test/com/gfredericks/test/chuck/exception_handling_test.cljc
+++ b/test/com/gfredericks/test/chuck/exception_handling_test.cljc
@@ -30,7 +30,7 @@
   (let [[test-results out]
         (capture-report-counters-and-out #'this-test-should-fail)]
     (is (not (re-find #"not-falsey-or-exception" out)))
-    (is (= {:pass 1 ; TODO: why 1? Not sure, but that's what's being reported
+    (is (= {:pass 0
             :fail 1
             :error 0}
            (select-keys test-results [:pass :fail :error])))))

--- a/test/com/gfredericks/test/chuck/exception_handling_test.cljc
+++ b/test/com/gfredericks/test/chuck/exception_handling_test.cljc
@@ -1,7 +1,8 @@
 (ns com.gfredericks.test.chuck.exception-handling-test
   (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :as test :refer [test-var test-vars *current-env*]
+               :cljs [cljs.test :as test :refer [test-vars]
                       :refer-macros [is testing deftest]])
+            [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking]]))
 
@@ -11,23 +12,6 @@
     (case i ; will throw when not in #{0 1}
       0 :zero
       1 :one)))
-
-(defn capture-test-var [v]
-  (with-out-str (test-var v)))
-
-(defn capture-report-counters-and-out [test]
-  #?(:clj
-     (binding [; need to keep the failure of the test
-               ; from affecting the clojure.test.check test run
-               *report-counters* (ref *initial-report-counters*)
-               *test-out* (java.io.StringWriter.)]
-       (capture-test-var test)
-       [@*report-counters* (str *test-out*)])
-
-     :cljs
-     (binding [*current-env* (test/empty-env)]
-       (let [out (capture-test-var test)]
-         [(:report-counters *current-env*) out]))))
 
 (deftest exception-detection-test
   (let [[test-results out]

--- a/test/com/gfredericks/test/chuck/runner.cljs
+++ b/test/com/gfredericks/test/chuck/runner.cljs
@@ -3,9 +3,11 @@
               [com.gfredericks.test.chuck.generators-test]
               [com.gfredericks.test.chuck.properties-test]
               [com.gfredericks.test.chuck.clojure-test-test]
+              [com.gfredericks.test.chuck.clojure-test-output-test]
               [com.gfredericks.test.chuck.exception-handling-test]))
 
 (doo-tests 'com.gfredericks.test.chuck.generators-test
            'com.gfredericks.test.chuck.properties-test
            'com.gfredericks.test.chuck.clojure-test-test
+           'com.gfredericks.test.chuck.clojure-test-output-test
            'com.gfredericks.test.chuck.exception-handling-test)

--- a/test/com/gfredericks/test/chuck/test_utils.cljc
+++ b/test/com/gfredericks/test/chuck/test_utils.cljc
@@ -1,0 +1,21 @@
+(ns com.gfredericks.test.chuck.test-utils
+  (:require #?(:clj  [clojure.test :refer :all]
+               :cljs [cljs.test :as test :refer [test-var *current-env*]])))
+
+(defn- capture-test-var [v]
+  (with-out-str (test-var v)))
+
+(defn capture-report-counters-and-out [test]
+  #?(:clj
+     (binding [; need to keep the failure of the test
+               ; from affecting the clojure.test.check test run
+               *report-counters* (ref *initial-report-counters*)
+               *test-out* (java.io.StringWriter.)]
+       (capture-test-var test)
+       [@*report-counters* (str *test-out*)])
+
+     :cljs
+     (binding [*current-env* (test/empty-env)]
+       (let [out (capture-test-var test)]
+         [(:report-counters *current-env*) out]))))
+


### PR DESCRIPTION
The checking macro was not printing the test.check result in case of
failures. This was happening since we changed the assertion on the
result of `checking` to only check if there was an exception. That
change was introduced to fix #17, which was about the output showing an
"expected: (not-falsey-or-exception? (:result result))" message. But
as a side-effect of that change, we lost the test.check result from the
output, which is very valuable.

The fix is to simply print the test.check result in case of failure.
This is part of what `do-report` would do if we called
`(is (:result result) result)` but now we avoid the other stuff that call
would do (incrementing test result counters, output the expected vs
actual result of the assertion, etc) by just calling `println`.

As a side-effect of this change, the `:pass` count in case of a failure
was fixed. That can be seen by the change in the failure-detecion-test

Fixes #28 