### PR TITLE
Update clojure-test to use test.chuck for-all

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -1,6 +1,6 @@
 (ns com.gfredericks.test.chuck.clojure-test
   (:require [clojure.test.check :as tc]
-            [clojure.test.check.properties :as prop
+            [com.gfredericks.test.chuck.properties :as prop
              #?@(:cljs [:include-macros true])]
             #?(:clj  [clojure.test :as ct :refer [is testing]]
                :cljs [cljs.test :as ct :refer-macros [is testing]])))


### PR DESCRIPTION
Update the `checking` and `for-all` macros in the `test.chuck.clojure-test`
namespace to use the `test.chuck.properties/for-all` function instead of `test.check.properties/for-all`.

Since the `test.chuck.properties/for-all` method is intended (AFAIK) to be a drop-in replacement for the vanilla `for-all`, I don't see any harm in doing this, and then the `clojure-test` functions can use all of the nice augmented functionality.

The test suite ran cleanly before and after this change, and some local testing of the new SNAPSHOT version allowed my app to correctly define a test using the enhanced `for-all` behavior in `checking`.