### PR TITLE
Extensible shrunk report

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -1,10 +1,14 @@
 (ns com.gfredericks.test.chuck.clojure-test
   (:require [clojure.test.check :as tc]
-            [clojure.test.check.clojure-test :as tcct]
             [com.gfredericks.test.chuck.properties :as prop
              #?@(:cljs [:include-macros true])]
             #?(:clj  [clojure.test :as ct :refer [is testing]]
                :cljs [cljs.test :as ct :refer-macros [is testing]])))
+
+;; exists in clojure.test.check.clojure-test v0.9.0
+(defn with-test-out* [f]
+  #?(:clj  (ct/with-test-out (f))
+     :cljs (f)))
 
 (defn ^:private not-exception?
   [value]
@@ -24,7 +28,7 @@
   (if (:result result)
     (is (not-exception? (:result result)) result)
     (do
-      (tcct/with-test-out*
+      (with-test-out*
         (fn [] (ct/report (shrunk-report result)))))))
 
 (defn pass? [reports]

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -1,22 +1,25 @@
 (ns com.gfredericks.test.chuck.clojure-test-output-test
-  (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer [test-vars] :refer-macros [deftest is]])
+  (:require #?(:clj  [clojure.test :as ct :refer [test-vars deftest is]]
+               :cljs [cljs.test :as ct :refer [test-vars] :refer-macros [deftest is]])
             #?(:cljs [cljs.reader :refer [read-string]])
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
-            [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking]]))
+            [com.gfredericks.test.chuck.clojure-test :as chuck #?(:clj :refer :cljs :refer-macros) [checking]]))
 
 (deftest a-failing-test
   (checking "all ints lt 5" 100
     [i gen/int]
     (is (< i 5))))
 
+(defmethod ct/report #?(:clj ::chuck/shrunk :cljs [::ct/default ::chuck/shrunk]) [m]
+  (println m))
+
 (deftest failure-output-test
-  (let [[test-results out] (capture-report-counters-and-out #'a-failing-test)]
+  (let [report-ptn #"\{.*:type :com.gfredericks.test.chuck.clojure-test/shrunk.*\}"
+        [test-results out] (capture-report-counters-and-out #'a-failing-test)]
     (is (re-find #"expected: \(< i 5\)" out))
     (is (re-find #"actual: \(not \(< \d 5\)" out))
-    (is (re-find #"\{.*:result false.*\}" out))
-    (let [tc-report (second (re-find #"(\{:result false.*\})" out))]
+    (let [tc-report (re-find report-ptn out)]
       (is tc-report)
       (when-let [tc-report (and tc-report (read-string tc-report))]
         (is (not (:result tc-report)))


### PR DESCRIPTION
For tools like `collection-check` it would be useful to provide some sort of hook to obtain the results of of the `quick-check` invocation that's part of the `checking` macro. 

This PR allows this extension via the regular `clojure.test/report` multimethod using namespaced keys similar to how `test.check` provides additional reporting functionality.

Adding this PR would greatly simplify the implementation of https://github.com/ztellman/collection-check/pull/13