### PR TITLE
Fix clojure-test-output-test by tweaking the expected output

### DIFF
--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -20,7 +20,7 @@
       (is tc-report)
       (when-let [tc-report (and tc-report (read-string tc-report))]
         (is (not (:result tc-report)))
-        (is (= [5] (get-in tc-report [:shrunk :smallest])))))))
+        (is (= [{'i 5}] (get-in tc-report [:shrunk :smallest])))))))
 
 (defn test-ns-hook []
   (test-vars [#'failure-output-test]))


### PR DESCRIPTION
The `:fail` and `:shrunk :smallest` entries in a failure report have changed to be a map of binding name to bound values since #30 when using `for-all` and `checking` macros.
The test clojure-test-output-test was originally written with the old output layout where it was just the vector of bound values, so this fixes it.

Fixes #31 