### PR TITLE
Upgrade test.check to 0.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0" :scope "provided"]
                  [org.clojure/clojurescript "1.7.48" :scope "provided"]
-                 [org.clojure/test.check "0.8.2"]
+                 [org.clojure/test.check "0.9.0"]
                  [clj-time "0.10.0"]
                  [com.andrewmcveigh/cljs-time "0.3.11"]
                  [instaparse "1.3.6"]]

--- a/test/com/gfredericks/test/chuck/generators_test.cljc
+++ b/test/com/gfredericks/test/chuck/generators_test.cljc
@@ -4,7 +4,8 @@
             [clojure.test.check.generators :as gen]
             [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
             [#?(:clj clj-time.coerce :cljs cljs-time.coerce) :as ctc]
-            [clojure.test.check.properties :as prop]
+            [clojure.test.check.properties :as prop
+             #?@(:cljs [:include-macros true])]
             [com.gfredericks.test.chuck.generators :as gen'
              #?@(:cljs [:include-macros true])]))
 


### PR DESCRIPTION
Also adds a missing `:include-macros` in `generators-test`