### PR TITLE
Resolves #39: Added cljs support for `times`

### DIFF
--- a/src/com/gfredericks/test/chuck.cljc
+++ b/src/com/gfredericks/test/chuck.cljc
@@ -4,9 +4,10 @@
   "Returns the multiplier for test-check runs, which can be set via
   the TEST_CHECK_FACTOR environment variable."
   []
-  (if-let [s (System/getenv "TEST_CHECK_FACTOR")]
-    (Double/parseDouble s)
-    1))
+  #?(:clj (if-let [s (System/getenv "TEST_CHECK_FACTOR")]
+            (Double/parseDouble s)
+            1)
+     :cljs 1))
 
 (defn times
   "A helper function for externally-configurable test run counts.
@@ -17,6 +18,8 @@
       ...)
 
   Simply returns n normally, but if the TEST_CHECK_FACTOR env variable
-  is set to a number, n will be multiplied by that number."
+  is set to a number, n will be multiplied by that number.
+
+  In clojurescript n is currently returned unmodified."
   [n]
   (long (* n (test-check-factor))))


### PR DESCRIPTION
The multiplication factor is always 1 in cljs.