### PR TITLE
Replace calls to bounded-int with gen/large-integer*

### DIFF
--- a/src/com/gfredericks/test/chuck/generators.cljc
+++ b/src/com/gfredericks/test/chuck/generators.cljc
@@ -238,8 +238,8 @@
      (scalb (core/double signed-significand) (core/int exp)))
    (gen/tuple
     (let [bignumber (apply * (repeat 52 2))]
-      (bounded-int (- bignumber) bignumber))
-    (bounded-int -1022 1023))))
+      (gen/large-integer* {:min (- bignumber) :max bignumber}))
+    (gen/large-integer* {:min -1022 :max 1023}))))
 
 #?(:clj
 (defn string-from-regex
@@ -319,5 +319,5 @@
                    offset-fn
                    (ct/plus base-datetime)))
              (gen/tuple (gen/elements offset-fns)
-                        (bounded-int offset-min
-                                     offset-max)))))
+                        (gen/large-integer* {:min offset-min
+                                             :max offset-max})))))


### PR DESCRIPTION
Avoids warnings due to calling a deprecated fn during cljs compilation.

Removes the following warning occurrences:

```
WARNING: com.gfredericks.test.chuck.generators/bounded-int is deprecated. at line 241 src/com/gfredericks/test/chuck/generators.cljc
WARNING: com.gfredericks.test.chuck.generators/bounded-int is deprecated. at line 242 src/com/gfredericks/test/chuck/generators.cljc
WARNING: com.gfredericks.test.chuck.generators/bounded-int is deprecated. at line 322 src/com/gfredericks/test/chuck/generators.cljc
```

The following warning is not removed because there's still a test for `bounded-int` in `generators-test`:

```
WARNING: com.gfredericks.test.chuck.generators/bounded-int is deprecated. at line 79 test/com/gfredericks/test/chuck/generators_test.cljc
```