### PR TITLE
Uses `pr-str` to ensure smallest test case is readable

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -21,7 +21,7 @@
 
 (defmethod ct/report #?(:clj ::shrunk :cljs [::ct/default ::shrunk]) [m]
   (newline)
-  (println "Tests failed, smallest case:" (-> m :shrunk :smallest)
+  (println "Tests failed, smallest case:" (pr-str (-> m :shrunk :smallest))
            "\nSeed" (:seed m)))
 
 (defn report-exception-or-shrunk [result]


### PR DESCRIPTION
For a test like this:

```clojure
(deftest property-test
  (checking
   "failing test"
   25
   [v (gen/vector gen/string)]
   (is (< (count v) 10))))
```

The message about the smallest failing case is hard to read: 

`Tests failed, smallest case: [{v [         ]}]`

By using `pr-str`, we get a more understandable message: 

`Tests failed, smallest case: [{v ["" "" "" "" "" "" "" "" "" ""]}]`