### PR TITLE
Report the failing is assertions in test.chuck.clojure-test/for-all

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -117,4 +117,6 @@
   `(prop/for-all
      ~bindings
      (let [reports# (capture-reports ~@body)]
+       (doseq [r# reports#]
+         (-report r#))
        (pass? reports#))))


### PR DESCRIPTION
I have had trouble with for-all for a while now, because it doesn't report back the failing assertions:

The point of this PR is to report back which assertions fail. Please let me know if you disagree with implementation and I'll fix it.

Previous behaviour:
```
{:result false, :seed 1468079929561, :failing-size 0, :num-tests 1, :fail [{n-jobs 1, job-ids [#uuid "4cda91f4-f7db-48ca-a246-852480444eef"], gen-cmds []}], :shrunk {:total-nodes-visited 0, :depth 0, :result false, :smallest [{n-jobs 1, job-ids [#uuid "4cda91f4-f7db-48ca-a246-852480444eef"], gen-cmds []}]}, :test-var "deterministic-abs-test"}
FAIL in (deterministic-abs-test) (clojure_test.cljc:21)
expected: result
  actual: false
```

New behaviour:
```
FAIL in (deterministic-abs-test) (deterministic_peer_test.clj:268)
not enough peers
expected: (>= n-peers 4)
  actual: (not (>= 0 4))
{:result false, :seed 1468079929561, :failing-size 0, :num-tests 1, :fail [{n-jobs 1, job-ids [#uuid "4cda91f4-f7db-48ca-a246-852480444eef"], gen-cmds []}], :shrunk {:total-nodes-visited 0, :depth 0, :result false, :smallest [{n-jobs 1, job-ids [#uuid "4cda91f4-f7db-48ca-a246-852480444eef"], gen-cmds []}]}, :test-var "deterministic-abs-test"}

FAIL in (deterministic-abs-test) (clojure_test.cljc:21)
expected: result
  actual: false
```
