### PR TITLE
Adds options to 'checking'

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -81,7 +81,7 @@
   (cond (map? num-tests-or-options)     (:num-tests num-tests-or-options tc.clojure-test/*default-test-count*)
         (integer? num-tests-or-options) num-tests-or-options))
 
-(defn other-options [num-tests-or-options]
+(defn options [num-tests-or-options]
   (cond (map? num-tests-or-options)     (dissoc num-tests-or-options :num-tests)
         (integer? num-tests-or-options) {}))
 
@@ -95,7 +95,7 @@
            (let [reports# (capture-reports ~@body)]
              (swap! ~final-reports save-to-final-reports reports#)
              (pass? reports#)))
-         (apply concat (other-options num-tests-or-options#))))))
+         (apply concat (options num-tests-or-options#))))))
 
 (defn -testing
   [name func]

--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -77,25 +77,25 @@
      (capture-reports* reports# (fn [] ~@body))
      @reports#))
 
-(defn times [options]
-  (cond (map? options)     (:num-tests options tc.clojure-test/*default-test-count*)
-        (integer? options) options))
+(defn times [num-tests-or-options]
+  (cond (map? num-tests-or-options)     (:num-tests num-tests-or-options tc.clojure-test/*default-test-count*)
+        (integer? num-tests-or-options) num-tests-or-options))
 
-(defn other-options [options]
-  (cond (map? options)     (dissoc options :num-tests)
-        (integer? options) {}))
+(defn other-options [num-tests-or-options]
+  (cond (map? num-tests-or-options)     (dissoc num-tests-or-options :num-tests)
+        (integer? num-tests-or-options) {}))
 
 (defmacro qc-and-report-exception
-  [final-reports options bindings & body]
+  [final-reports num-tests-or-options bindings & body]
   `(report-exception-or-shrunk
-     (let [options# ~options]
+     (let [num-tests-or-options# ~num-tests-or-options]
        (apply tc/quick-check
-         (times options#)
+         (times num-tests-or-options#)
          (prop/for-all ~bindings
            (let [reports# (capture-reports ~@body)]
              (swap! ~final-reports save-to-final-reports reports#)
              (pass? reports#)))
-         (apply concat (other-options options#))))))
+         (apply concat (other-options num-tests-or-options#))))))
 
 (defn -testing
   [name func]
@@ -115,11 +115,11 @@
   (checking \"doubling\" {:num-tests 100 :seed 123 :max-size 10} [x gen/int] (is (= (* 2 x) (+ x x)))).
 
   For more details on this code, see http://blog.colinwilliams.name/blog/2015/01/26/alternative-clojure-dot-test-integration-with-test-dot-check/"
-  [name options bindings & body]
+  [name num-tests-or-options bindings & body]
   `(-testing ~name
     (fn []
       (let [final-reports# (atom [])]
-        (qc-and-report-exception final-reports# ~options ~bindings ~@body)
+        (qc-and-report-exception final-reports# ~num-tests-or-options ~bindings ~@body)
         (doseq [r# @final-reports#]
           (-report r#))))))
 

--- a/test/com/gfredericks/test/chuck/clojure_test_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_test.cljc
@@ -11,6 +11,20 @@
   (checking "negative" 100 [i gen/s-neg-int]
     (is (< i 0))))
 
+(deftest options-test
+  ;; empty map is OK, defaults to 100 tests
+  (checking "strings are strings" {} [s gen/string-ascii]
+    (is (string? s)))
+  ;; passes because the number of tests is small
+  (checking "small ints" {:num-tests 5} [i gen/s-pos-int]
+    (is (< i 10)))
+  ;; passes only because of seed
+  (checking "specific values" {:num-tests 5 :seed 12345678} [i gen/int]
+    (is (contains? #{-1 0 1} i)))
+  ;; passes because of max-size
+  (checking "short strings" {:num-tests 100 :max-size 9} [s gen/string-ascii]
+    (is (< (count s) 10))))
+
 (deftest counter
   (checking "increasing" 100 [i gen/s-pos-int]
     (let [c (atom i)]


### PR DESCRIPTION
Fixes https://github.com/gfredericks/test.chuck/issues/48

The `:reporter-fn` option to `quick-check` is not available on `test.check` 0.9.0, so there is no tests for it, but it should work without further modification.

To maintain backwards compatibility, I have (optionally) replaced the number of tests with a map containing all options e.g.

```clojure
(checking "less than 10" {:num-tests 11 :seed 123} [i gen/int]
  (is (< i 10)))
```

This form mirrors the way you can optionally use `defspec`:

```clojure
(defspec less-than-10 {:num-tests 11 :seed 123}
  (prop/for-all [i gen/int]
        (< i 10)))
```