### PR TITLE
Support `testing` inside `checking` and make `checking` options optional

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -123,20 +123,22 @@
 
   generative, you simply have to change it to
 
-    (checking \"doubling\" [x gen/int]
+    (checking \"doubling\"
+      [x gen/int]
       (is (= (* 2 x) (+ x x)))).
 
   Test failures will be reported for the smallest case only.
 
   Bindings and body are passed to com.gfredericks.test.chuck.properties/for-all.
 
-  Options can be provided to `clojure.test.check/quick-check` when the second
-  argument is an integer (number of tests) or a map (with :num-tests being the
-  number of tests). e.g.:
+  Options can be provided to `clojure.test.check/quick-check` as an optional
+  second argument, and should either evaluate to an integer (number of tests) or a
+  map (with :num-tests specifying the number of tests). e.g.:
 
-    (checking \"doubling\" {:num-tests 100 :seed 123 :max-size 10}
-      [x gen/int]
-      (is (= (* 2 x) (+ x x))))
+    (let [options {:num-tests 100 :seed 123 :max-size 10}]
+      (checking \"doubling\" options
+        [x gen/int]
+        (is (= (* 2 x) (+ x x)))))
 
   For background, see
   http://blog.colinwilliams.name/blog/2015/01/26/alternative-clojure-dot-test-integration-with-test-dot-check/"

--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -22,15 +22,14 @@
 
 (defmethod ct/report #?(:clj ::shrunk :cljs [::ct/default ::shrunk]) [m]
   (newline)
-  (println "Tests failed, smallest case:" (pr-str (-> m :shrunk :smallest))
-           "\nSeed" (:seed m)))
+  (println (str "Tests failed, smallest case: " (pr-str (-> m :shrunk :smallest))
+                "\nSeed: " (:seed m))))
 
 (defn report-exception-or-shrunk [result]
   (if (:result result)
     (is (not-exception? (:result result)) result)
-    (do
-      (with-test-out*
-        (fn [] (ct/report (shrunk-report result)))))))
+    (with-test-out*
+      (fn [] (ct/report (shrunk-report result))))))
 
 (defn pass? [reports]
   (every? #(= (:type %) :pass) reports))
@@ -48,33 +47,34 @@
 #?(:cljs
 (defmethod ct/report [::chuck-capture :error]
   [m]
-  (swap! *chuck-captured-reports* conj m)))
+  (swap! *chuck-captured-reports* conj (assoc m ::testing-contexts (:testing-contexts (ct/get-current-env))))))
 
 #?(:cljs
 (defmethod ct/report [::chuck-capture :fail]
   [m]
-  (swap! *chuck-captured-reports* conj m)))
+  (swap! *chuck-captured-reports* conj (assoc m ::testing-contexts (:testing-contexts (ct/get-current-env))))))
 
 #?(:cljs
 (defmethod ct/report [::chuck-capture :pass]
   [m]
-  (swap! *chuck-captured-reports* conj m)))
+  (swap! *chuck-captured-reports* conj (assoc m ::testing-contexts (:testing-contexts (ct/get-current-env))))))
 
 (defn capture-reports*
   [reports-atom f]
   #?(:clj
-     (binding [ct/report #(swap! reports-atom conj %)]
+     (binding [ct/report #(swap! reports-atom conj (assoc % ::testing-contexts ct/*testing-contexts*))]
        (f))
 
      :cljs
      (binding [*chuck-captured-reports* reports-atom
-               cljs.test/*current-env* (cljs.test/empty-env ::chuck-capture)]
+               ct/*current-env* (assoc (ct/empty-env ::chuck-capture)
+                                       :testing-contexts (:testing-contexts (ct/get-current-env)))]
        (f))))
 
 (defmacro capture-reports
   [& body]
   `(let [reports# (atom [])]
-     (capture-reports* reports# (fn [] ~@body))
+     (capture-reports* reports# (fn [] (do ~@body)))
      @reports#))
 
 (defn times [num-tests-or-options]
@@ -88,12 +88,13 @@
 (defmacro qc-and-report-exception
   [final-reports num-tests-or-options bindings & body]
   `(report-exception-or-shrunk
-     (let [num-tests-or-options# ~num-tests-or-options]
+     (let [num-tests-or-options# ~num-tests-or-options
+           final-reports# ~final-reports]
        (apply tc/quick-check
          (times num-tests-or-options#)
          (prop/for-all ~bindings
            (let [reports# (capture-reports ~@body)]
-             (swap! ~final-reports save-to-final-reports reports#)
+             (swap! final-reports# save-to-final-reports reports#)
              (pass? reports#)))
          (apply concat (options num-tests-or-options#))))))
 
@@ -102,17 +103,36 @@
   (testing name (func)))
 
 (defn -report
-  [reports]
-  (ct/report reports))
+  [report]
+  #?(:clj
+     (binding [ct/*testing-contexts* (::testing-contexts report)]
+       (ct/report report))
+     :cljs
+     (let [old-env (ct/get-current-env)]
+       (ct/set-env! (assoc old-env :testing-contexts (::testing-contexts report)))
+       (try (ct/report report)
+            (finally
+              (ct/set-env! (assoc (ct/get-current-env) :testing-contexts (:testing-contexts old-env))))))))
 
 (defmacro checking
   "A macro intended to replace the testing macro in clojure.test with a
-  generative form. To make (testing \"doubling\" (is (= (* 2 2) (+ 2 2))))
-  generative, you simply have to change it to
-  (checking \"doubling\" 100 [x gen/int] (is (= (* 2 x) (+ x x)))).
+  generative form. To make
 
-  You can optionally pass in a map of options instead of the number of tests,
-  which will be passed to `clojure.test.check/quick-check`, e.g.:
+    (testing \"doubling\"
+      (is (= (* 2 2) (+ 2 2))))
+
+  generative, you simply have to change it to
+
+    (checking \"doubling\" [x gen/int]
+      (is (= (* 2 x) (+ x x)))).
+
+  Test failures will be reported for the smallest case only.
+
+  Bindings and body are passed to com.gfredericks.test.chuck.properties/for-all.
+
+  Options can be provided to `clojure.test.check/quick-check` when the second
+  argument is an integer (number of tests) or a map (with :num-tests being the
+  number of tests). e.g.:
 
     (checking \"doubling\" {:num-tests 100 :seed 123 :max-size 10}
       [x gen/int]
@@ -120,18 +140,25 @@
 
   For background, see
   http://blog.colinwilliams.name/blog/2015/01/26/alternative-clojure-dot-test-integration-with-test-dot-check/"
-  [name num-tests-or-options bindings & body]
-  `(-testing ~name
-    (fn []
-      (let [final-reports# (atom [])]
-        (qc-and-report-exception final-reports# ~num-tests-or-options ~bindings ~@body)
-        (doseq [r# @final-reports#]
-          (-report r#))))))
+  {:forms '[(checking name num-tests-or-options? [bindings*] body*)]}
+  [name & opt+body]
+  (let [[num-tests-or-options opt+body] (if (vector? (first opt+body))
+                                          [{} opt+body]
+                                          ((juxt first next) opt+body)) 
+        [bindings & body] opt+body]
+    `(let [final-reports# (atom [])]
+       (-testing ~name
+         (fn []
+           (qc-and-report-exception final-reports# ~num-tests-or-options ~bindings ~@body)))
+       (doseq [r# @final-reports#]
+         (-report r#)))))
 
 (defmacro for-all
-  "An alternative to clojure.test.check.properties/for-all that uses
+  "An alternative to com.gfredericks.test.chuck.properties/for-all that uses
   clojure.test-style assertions (i.e., clojure.test/is) rather than
-  the truthiness of the body expression."
+  the truthiness of the body expression.
+  
+  See `checking` to additionally report clojure.test assertion failures."
   [bindings & body]
   `(prop/for-all
      ~bindings

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -1,7 +1,9 @@
 (ns com.gfredericks.test.chuck.clojure-test-output-test
-  (:require #?(:clj  [clojure.test :as ct :refer [test-vars deftest is]]
-               :cljs [cljs.test :as ct :refer [test-vars] :refer-macros [deftest is]])
+  (:require #?(:clj  [clojure.test :as ct :refer [test-vars deftest is testing]]
+               :cljs [cljs.test :as ct :refer [test-vars] :refer-macros [deftest is testing]])
             #?(:cljs [cljs.reader :refer [read-string]])
+            [clojure.pprint :as pp]
+            [clojure.string :as str]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
             [com.gfredericks.test.chuck.clojure-test :as chuck #?(:clj :refer :cljs :refer-macros) [checking]]))
@@ -9,21 +11,45 @@
 (deftest a-failing-test
   (checking "all ints lt 5" 100
     [i gen/int]
-    (is (< i 5))))
+    (testing "test `testing` logging1"
+      (is (< i 5) "test `is` logging1"))
+    (testing "test `testing` logging2"
+      (is (< i 5 6) "test `is` logging2"))))
 
 (defmethod ct/report #?(:clj ::chuck/shrunk :cljs [::ct/default ::chuck/shrunk]) [m]
   (println m))
 
 (deftest failure-output-test
-  (let [report-ptn #"\{.*:type :com.gfredericks.test.chuck.clojure-test/shrunk.*\}"
-        [test-results out] (capture-report-counters-and-out #'a-failing-test)]
-    (is (re-find #"expected: \(< i 5\)" out))
-    (is (re-find #"actual: \(not \(< \d 5\)" out))
-    (let [tc-report (re-find report-ptn out)]
-      (is tc-report)
-      (when-let [tc-report (and tc-report (read-string tc-report))]
-        (is (not (:result tc-report)))
-        (is (= [{'i 5}] (get-in tc-report [:shrunk :smallest])))))))
+  (let [[test-results out] (capture-report-counters-and-out #'a-failing-test)
+        ;; shrunk map should be printed first
+        tc-report (read-string out)
+        ;; clearly distinguish between actual test returns and simulated ones
+        msg (with-out-str (pp/pprint (str/split-lines out)))]
+    (testing "clojure.test reporting"
+      (is (= test-results {:test 1, :pass 0, :fail 2, :error 0}))
+      (is (str/includes? 
+            out
+            (str/join
+              \newline
+              ["all ints lt 5 test `testing` logging1"
+               "test `is` logging1"
+               "expected: (< i 5)"
+               "  actual: (not (< 5 5))"]))
+          msg)
+      (is (str/includes?
+            out 
+            (str/join
+              \newline
+              ["all ints lt 5 test `testing` logging2"
+               "test `is` logging2"
+               "expected: (< i 5 6)"
+               "  actual: (not (< 5 5 6))"]))
+          msg))
+    (testing "test.check reporting"
+      (is (map? tc-report))
+      (is (= :com.gfredericks.test.chuck.clojure-test/shrunk (:type tc-report)))
+      (is (not (:result tc-report)))
+      (is (= [{'i 5}] (get-in tc-report [:shrunk :smallest]))))))
 
 (defn test-ns-hook []
   (test-vars [#'failure-output-test]))

--- a/test/com/gfredericks/test/chuck/clojure_test_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_test.cljc
@@ -12,8 +12,10 @@
     (is (< i 0))))
 
 (deftest options-test
-  ;; empty map is OK, defaults to 100 tests
+  ;; empty map or no options are OK, defaults to 100 tests
   (checking "strings are strings" {} [s gen/string-ascii]
+    (is (string? s)))
+  (checking "strings are strings" [s gen/string-ascii]
     (is (string? s)))
   ;; passes because the number of tests is small
   (checking "small ints" {:num-tests 5} [i gen/s-pos-int]


### PR DESCRIPTION
Close https://github.com/gfredericks/test.chuck/issues/57

This PR adds support for nesting `testing` inside `checking` forms and makes the options argument to `checking` optional.