### PR TITLE
Analyse `(checking` description in clj-kondo hook

### DIFF
--- a/resources/clj-kondo.exports/com.gfredericks/test.chuck/clj_kondo/com/gfredericks/test/chuck/checking.clj
+++ b/resources/clj-kondo.exports/com.gfredericks/test.chuck/clj_kondo/com/gfredericks/test/chuck/checking.clj
@@ -4,7 +4,7 @@
 
 (defn checking
   [{{:keys [children]} :node}]
-  (let [[_checking _desc & opt+bindings+body] children
+  (let [[_checking desc & opt+bindings+body] children
         [opts binding-vec & body]             (if (api/vector-node? (first opt+bindings+body))
                                                 (into [(api/map-node {})] opt+bindings+body)
                                                 opt+bindings+body)]
@@ -13,6 +13,7 @@
     {:node (api/list-node
             (list*
              (api/token-node 'let)
-             (api/vector-node (into [] (:children binding-vec)))
+             (api/vector-node (into [(api/token-node (symbol (gensym "_checking-desc"))) desc]
+                                    (:children binding-vec)))
              opts
              body))}))


### PR DESCRIPTION
This is a follow-up to https://github.com/gfredericks/test.chuck/pull/69.

This makes `clj-kondo` analyse `(checking` form *description* too, which makes a difference if it's not a literal, for example:
```clojure
(ns checking-test
 (:require [my.ns :as some-ns-that-would-be-flagged-as-unused-without-this-change]))

...

(checking (some-ns-that-would-be-flagged-as-unused-without-this-change/myfun) 100 ...)
```