### PR TITLE
Add self-require forms, fix linter errors

### DIFF
--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -2,8 +2,7 @@
   (:require [clojure.test.check :as tc]
             [clojure.test.check.clojure-test :as tc.clojure-test]
             [com.gfredericks.test.chuck.properties :as prop]
-            #?(:clj  [clojure.test :as ct :refer [is testing]]
-               :cljs [cljs.test :as ct :refer-macros [is testing]]))
+            [clojure.test :as ct :refer [is testing]])
   #?(:cljs
      (:require-macros [com.gfredericks.test.chuck.clojure-test])))
 

--- a/src/com/gfredericks/test/chuck/clojure_test.cljc
+++ b/src/com/gfredericks/test/chuck/clojure_test.cljc
@@ -1,10 +1,11 @@
 (ns com.gfredericks.test.chuck.clojure-test
   (:require [clojure.test.check :as tc]
             [clojure.test.check.clojure-test :as tc.clojure-test]
-            [com.gfredericks.test.chuck.properties :as prop
-             #?@(:cljs [:include-macros true])]
+            [com.gfredericks.test.chuck.properties :as prop]
             #?(:clj  [clojure.test :as ct :refer [is testing]]
-               :cljs [cljs.test :as ct :refer-macros [is testing]])))
+               :cljs [cljs.test :as ct :refer-macros [is testing]]))
+  #?(:cljs
+     (:require-macros [com.gfredericks.test.chuck.clojure-test])))
 
 ;; exists in clojure.test.check.clojure-test v0.9.0
 (defn with-test-out* [f]
@@ -146,12 +147,12 @@
   [name & opt+body]
   (let [[num-tests-or-options opt+body] (if (vector? (first opt+body))
                                           [{} opt+body]
-                                          ((juxt first next) opt+body)) 
+                                          ((juxt first next) opt+body))
         [bindings & body] opt+body]
     `(let [final-reports# (atom [])]
        (-testing ~name
-         (fn []
-           (qc-and-report-exception final-reports# ~num-tests-or-options ~bindings ~@body)))
+                 (fn []
+                   (qc-and-report-exception final-reports# ~num-tests-or-options ~bindings ~@body)))
        (doseq [r# @final-reports#]
          (-report r#)))))
 
@@ -159,10 +160,10 @@
   "An alternative to com.gfredericks.test.chuck.properties/for-all that uses
   clojure.test-style assertions (i.e., clojure.test/is) rather than
   the truthiness of the body expression.
-  
+
   See `checking` to additionally report clojure.test assertion failures."
   [bindings & body]
   `(prop/for-all
-     ~bindings
-     (let [reports# (capture-reports ~@body)]
-       (pass? reports#))))
+    ~bindings
+    (let [reports# (capture-reports ~@body)]
+      (pass? reports#))))

--- a/src/com/gfredericks/test/chuck/generators.cljc
+++ b/src/com/gfredericks/test/chuck/generators.cljc
@@ -1,12 +1,12 @@
 (ns com.gfredericks.test.chuck.generators
   "Yes this namespace's name has five components."
   (:refer-clojure :exclude [double for partition])
-  #?(:cljs (:require-macros [com.gfredericks.test.chuck.generators :refer [for]]))
   (:require [clojure.test.check.generators :as gen]
             [#?(:clj clojure.core :cljs cljs.core) :as core]
             [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
-            [#?(:clj clj-time.coerce :cljs cljs-time.coerce) :as ctc]
-            #?(:clj [com.gfredericks.test.chuck.regexes :as regexes])))
+            #?(:clj [com.gfredericks.test.chuck.regexes :as regexes]))
+  #?(:cljs
+     (:require-macros [com.gfredericks.test.chuck.generators :refer [for]])))
 
 ;; Hoping this will be in test.check proper:
 ;; http://dev.clojure.org/jira/browse/TCHECK-15
@@ -131,7 +131,7 @@
 
             (= k2 :when)
             (let [max-tries-meta (-> v2 meta :max-tries)
-                  max-tries-arg (if max-tries-meta
+                  max-tries-arg (when max-tries-meta
                                   [max-tries-meta])
                   v1' `(gen/such-that (fn [~k1] ~v2) ~v1 ~@max-tries-arg)]
               `(for [~k1 ~v1' ~@even-more] ~expr))

--- a/src/com/gfredericks/test/chuck/properties.cljc
+++ b/src/com/gfredericks/test/chuck/properties.cljc
@@ -3,8 +3,9 @@
   (:require [clojure.set :as sets]
             [clojure.test.check.properties :as prop
              #?@(:cljs [:include-macros true])]
-            [com.gfredericks.test.chuck.generators :as gen'
-             #?@(:cljs [:include-macros true])]))
+            [com.gfredericks.test.chuck.generators :as gen'])
+  #?(:cljs
+     (:require-macros [com.gfredericks.test.chuck.properties])))
 
 ;; This namespace goes to a heck of a lot of effort just to get sane
 ;; args reported when a property fails. It semiduplicates syntactic

--- a/src/com/gfredericks/test/chuck/regexes/charsets.clj
+++ b/src/com/gfredericks/test/chuck/regexes/charsets.clj
@@ -5,8 +5,7 @@
   Character class directly. Instead the API uses strings of
   one character (for small unicode characters) or two surrogates
   (for large unicode characters)."
-  (:refer-clojure :exclude [empty nth range])
-  (:import [clojure.lang IPersistentVector]))
+  (:refer-clojure :exclude [empty nth range]))
 
 (defn ^:private entry-size
   [[x1 x2]]

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -1,6 +1,5 @@
 (ns com.gfredericks.test.chuck.clojure-test-output-test
-  (:require #?(:clj  [clojure.test :as ct :refer [test-vars deftest is testing]]
-               :cljs [cljs.test :as ct :refer [test-vars] :refer-macros [deftest is testing]])
+  (:require [clojure.test :as ct :refer [test-vars deftest is testing]]
             #?(:cljs [cljs.reader :refer [read-string]])
             [clojure.edn :as edn]
             [clojure.pprint :as pp]
@@ -39,22 +38,22 @@
     (testing "clojure.test reporting"
       (is (= test-results {:test 1, :pass 0, :fail 2, :error 0}))
       (is (str/includes?
-            out
-            (str/join
-              \newline
-              ["all ints lt 5 test `testing` logging1"
-               "test `is` logging1"
-               "expected: (< i 5)"
-               "  actual: (not (< 5 5))"]))
+           out
+           (str/join
+            \newline
+            ["all ints lt 5 test `testing` logging1"
+             "test `is` logging1"
+             "expected: (< i 5)"
+             "  actual: (not (< 5 5))"]))
           msg)
       (is (str/includes?
-            out
-            (str/join
-              \newline
-              ["all ints lt 5 test `testing` logging2"
-               "test `is` logging2"
-               "expected: (< i 5 6)"
-               "  actual: (not (< 5 5 6))"]))
+           out
+           (str/join
+            \newline
+            ["all ints lt 5 test `testing` logging2"
+             "test `is` logging2"
+             "expected: (< i 5 6)"
+             "  actual: (not (< 5 5 6))"]))
           msg))
     (testing "test.check reporting"
       (is (map? tc-report))

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -7,7 +7,7 @@
             [clojure.string :as str]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
-            [com.gfredericks.test.chuck.clojure-test :as chuck #?(:clj :refer :cljs :refer-macros) [checking]]))
+            [com.gfredericks.test.chuck.clojure-test :as chuck :refer [checking]]))
 
 (deftest a-failing-test
   (checking "all ints lt 5" 100
@@ -38,7 +38,7 @@
         msg (with-out-str (pp/pprint (str/split-lines out)))]
     (testing "clojure.test reporting"
       (is (= test-results {:test 1, :pass 0, :fail 2, :error 0}))
-      (is (str/includes? 
+      (is (str/includes?
             out
             (str/join
               \newline
@@ -48,7 +48,7 @@
                "  actual: (not (< 5 5))"]))
           msg)
       (is (str/includes?
-            out 
+            out
             (str/join
               \newline
               ["all ints lt 5 test `testing` logging2"

--- a/test/com/gfredericks/test/chuck/clojure_test_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_test.cljc
@@ -4,7 +4,7 @@
             [clojure.test.check :refer [quick-check]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck :refer [times]]
-            [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking for-all]]))
+            [com.gfredericks.test.chuck.clojure-test :refer [checking for-all]]))
 
 (deftest integer-facts
   (checking "positive" (times 100) [i gen/s-pos-int]

--- a/test/com/gfredericks/test/chuck/clojure_test_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_test.cljc
@@ -1,6 +1,5 @@
 (ns com.gfredericks.test.chuck.clojure-test-test
-  (:require #?(:clj  [clojure.test :refer :all])
-            #?(:cljs [cljs.test :refer-macros [deftest is]])
+  (:require [clojure.test :refer [deftest is]]
             [clojure.test.check :refer [quick-check]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck :refer [times]]

--- a/test/com/gfredericks/test/chuck/exception_handling_test.cljc
+++ b/test/com/gfredericks/test/chuck/exception_handling_test.cljc
@@ -1,10 +1,10 @@
 (ns com.gfredericks.test.chuck.exception-handling-test
   (:require #?(:clj  [clojure.test :refer :all]
                :cljs [cljs.test :as test :refer [test-vars]
-                      :refer-macros [is testing deftest]])
+                      :refer-macros [is deftest]])
             [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
             [clojure.test.check.generators :as gen]
-            [com.gfredericks.test.chuck.clojure-test #?(:clj :refer :cljs :refer-macros) [checking]]))
+            [com.gfredericks.test.chuck.clojure-test :refer [checking]]))
 
 (deftest this-test-should-crash-and-be-caught
   (checking "an int is zero or one" 100 [i gen/int]

--- a/test/com/gfredericks/test/chuck/exception_handling_test.cljc
+++ b/test/com/gfredericks/test/chuck/exception_handling_test.cljc
@@ -1,7 +1,5 @@
 (ns com.gfredericks.test.chuck.exception-handling-test
-  (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :as test :refer [test-vars]
-                      :refer-macros [is deftest]])
+  (:require [clojure.test :refer [test-vars is deftest]]
             [com.gfredericks.test.chuck.test-utils :refer [capture-report-counters-and-out]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]))

--- a/test/com/gfredericks/test/chuck/generators_test.cljc
+++ b/test/com/gfredericks/test/chuck/generators_test.cljc
@@ -3,11 +3,9 @@
              #?(:clj :refer :cljs :refer-macros) [defspec]]
             [clojure.test.check.generators :as gen]
             [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
-            [#?(:clj clj-time.coerce :cljs cljs-time.coerce) :as ctc]
             [clojure.test.check.properties :as prop
              #?@(:cljs [:include-macros true])]
-            [com.gfredericks.test.chuck.generators :as gen'
-             #?@(:cljs [:include-macros true])]))
+            [com.gfredericks.test.chuck.generators :as gen']))
 
 (def lists-and-counts
   (gen'/for [nums (gen/vector gen/nat)

--- a/test/com/gfredericks/test/chuck/generators_test.cljc
+++ b/test/com/gfredericks/test/chuck/generators_test.cljc
@@ -1,10 +1,8 @@
 (ns com.gfredericks.test.chuck.generators-test
-  (:require [clojure.test.check.clojure-test
-             #?(:clj :refer :cljs :refer-macros) [defspec]]
+  (:require [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
-            [clojure.test.check.properties :as prop
-             #?@(:cljs [:include-macros true])]
+            [clojure.test.check.properties :as prop]
             [com.gfredericks.test.chuck.generators :as gen']))
 
 (def lists-and-counts

--- a/test/com/gfredericks/test/chuck/properties_test.cljc
+++ b/test/com/gfredericks/test/chuck/properties_test.cljc
@@ -1,11 +1,9 @@
 (ns com.gfredericks.test.chuck.properties-test
   (:require [clojure.test.check :as tc]
             [clojure.test.check.generators :as gen]
-            [clojure.test.check.clojure-test :as ct
-             #?(:clj :refer :cljs :refer-macros) [defspec]]
+            [clojure.test.check.clojure-test :as ct :refer [defspec]]
             [com.gfredericks.test.chuck.properties :as prop']
-            #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest is]])))
+            [clojure.test :refer [deftest is]]))
 
 (deftest it-handles-exceptions-correctly
   (is

--- a/test/com/gfredericks/test/chuck/properties_test.cljc
+++ b/test/com/gfredericks/test/chuck/properties_test.cljc
@@ -3,10 +3,7 @@
             [clojure.test.check.generators :as gen]
             [clojure.test.check.clojure-test :as ct
              #?(:clj :refer :cljs :refer-macros) [defspec]]
-            [com.gfredericks.test.chuck.properties :as prop'
-             #?@(:cljs [:include-macros true])]
-            [com.gfredericks.test.chuck.generators :as gen'
-             #?@(:cljs [:include-macros true])]
+            [com.gfredericks.test.chuck.properties :as prop']
             #?(:clj  [clojure.test :refer :all]
                :cljs [cljs.test :refer-macros [deftest is]])))
 


### PR DESCRIPTION
This PR:

- adds `:require-macros` forms to each cljc namespace that includes macros. This removes the need for `:include-macros true` or `:refer-macros` for users of the library... the advantage shows in the test changes here!
- fixes most linter errors that clj-kondo revealed in the `src` directory.