### PR TITLE
Use clj-kondo config inside project, add :lint-as

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/com.gfredericks/test.chuck"]}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.clj-kondo/.cache

--- a/resources/clj-kondo.exports/com.gfredericks/test.chuck/config.edn
+++ b/resources/clj-kondo.exports/com.gfredericks/test.chuck/config.edn
@@ -1,4 +1,9 @@
-{:hooks
+{:lint-as
+ {com.gfredericks.test.chuck.generators/for clojure.core/for
+  com.gfredericks.test.chuck.generators/for-all clojure.core/for
+  com.gfredericks.test.chuck.clojure-test/for-all clojure.core/for}
+
+ :hooks
  {:analyze-call
   {com.gfredericks.test.chuck.clojure-test/checking
    clj-kondo.com.gfredericks.test.chuck.checking/checking}}}


### PR DESCRIPTION
This PR adds a clj-kondo config to test.chuck proper, pointing at its own exported config.