### PR TITLE
Close #78: print seed on generation error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]
                  [org.clojure/clojurescript "1.10.879" :scope "provided"]
-                 [org.clojure/test.check "1.1.0"]
+                 ;;https://github.com/frenchy64/test.check/pull/1
+                 [org.clojure/test.check "6e866f163c82ccfe95f0a667d5d8a6c20813c279"]
                  [clj-time "0.15.2"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [instaparse "1.4.10"]]
@@ -13,7 +14,11 @@
   :profiles {:ci {:jvm-opts ["-Xmx1g" "-server"]}}
   :plugins [[lein-cljsbuild "1.1.8"]
             [lein-doo "0.1.11"]
-            [com.gfredericks/lein-all-my-files-should-end-with-exactly-one-newline-character "0.1.0"]]
+            [com.gfredericks/lein-all-my-files-should-end-with-exactly-one-newline-character "0.1.0"]
+            [reifyhealth/lein-git-down "0.3.5"]]
+  :middleware [lein-git-down.plugin/inject-properties]
+  :repositories [["public-github" {:url "git://github.com"}]]
+  :git-down {org.clojure/test.check {:coordinates frenchy64/test.check}}
 
   :cljsbuild
   {:builds


### PR DESCRIPTION
As suggested in #78 this required changes in test.check. Those will need to be merged before this PR can be merged.