### PR TITLE
Babashka compatibility

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,9 @@
+{:paths ["src"]
+ :deps {local/deps {:local/root "."}}
+ :tasks {test {:extra-deps {io.github.cognitect-labs/test-runner
+                            {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+               :extra-paths ["test"]
+               :task (exec 'cognitect.test-runner.api/test)
+               :exec-args {:dirs ["test"]}
+               :org.babashka/cli {:coerce {:nses [:symbol]
+                                           :vars [:symbol]}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,5 @@
  :deps {org.clojure/test.check {:mvn/version "1.1.0"}
         clj-time/clj-time {:mvn/version "0.15.2"}
         com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}
-        instaparse/instaparse {:mvn/version "1.4.10"}}}
+        instaparse/instaparse {:mvn/version "1.4.10"}
+        io.github.babashka/instaparse-bb {:git/sha "1a7a9b8", :git/tag "v0.0.5"}}}

--- a/src/com/gfredericks/test/chuck/generators.cljc
+++ b/src/com/gfredericks/test/chuck/generators.cljc
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [double for partition])
   (:require [clojure.test.check.generators :as gen]
             [#?(:clj clojure.core :cljs cljs.core) :as core]
-            [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
+            #?@(:bb [] :clj [[clj-time.core :as ct]] :cljs [[cljs-time.core :as ct]])
             #?(:clj [com.gfredericks.test.chuck.regexes :as regexes]))
   #?(:cljs
      (:require-macros [com.gfredericks.test.chuck.generators :refer [for]])))
@@ -268,12 +268,19 @@
               (select-keys m ks))
             (subsequence (keys m))))
 
+#?(:bb nil :default
 (def valid-offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months ct/years])
+)
 
+#?(:bb nil :default
 (def ^:private valid-offset-fn? (set valid-offset-fns))
+)
 
+#?(:bb nil :default
 (def ^:private yr-2000 (ct/date-time 2000))
+)
 
+#?(:bb nil :default
 (defn datetime
   "Generates datetime within given range and format.
 
@@ -321,6 +328,7 @@
              (gen/tuple (gen/elements offset-fns)
                         (gen/large-integer* {:min offset-min
                                              :max offset-max})))))
+)
 
 (defn- bounded-recursive-helper
   [container-gen-fn scalar-gen scalar-size max-breadth curr-height]

--- a/src/com/gfredericks/test/chuck/generators.cljc
+++ b/src/com/gfredericks/test/chuck/generators.cljc
@@ -3,8 +3,8 @@
   (:refer-clojure :exclude [double for partition])
   (:require [clojure.test.check.generators :as gen]
             [#?(:clj clojure.core :cljs cljs.core) :as core]
-            #?@(:bb [] :clj [[clj-time.core :as ct]] :cljs [[cljs-time.core :as ct]])
-            #?(:clj [com.gfredericks.test.chuck.regexes :as regexes]))
+            #?(:clj [com.gfredericks.test.chuck.regexes :as regexes])
+            #?(:cljs [com.gfredericks.test.chuck.generators.clj-time :as ct]))
   #?(:cljs
      (:require-macros [com.gfredericks.test.chuck.generators :refer [for]])))
 
@@ -268,67 +268,19 @@
               (select-keys m ks))
             (subsequence (keys m))))
 
-#?(:bb nil :default
-(def valid-offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months ct/years])
-)
-
-#?(:bb nil :default
-(def ^:private valid-offset-fn? (set valid-offset-fns))
-)
-
-#?(:bb nil :default
-(def ^:private yr-2000 (ct/date-time 2000))
-)
-
-#?(:bb nil :default
-(defn datetime
-  "Generates datetime within given range and format.
-
-   base-datetime => By default it'll calculate the dates from year 2000.
-                    Generally this is a good idea instead of using (ct/now)
-                    since giving the same seed will generate the same output.
-                    If you would like to generate from a differnt base-datetime,
-                    Pass for example (ct/now) to use current time,
-                    Or pass a specific date-time (ct/date-time 2011 11 24)
-
-   offset-min & offset-max => The offset number range
-                              By default it is -1000 to 1000
-
-   offset-fns => List of functions which will be used with the given offset.
-                 It randomly picks one of the functions and
-                 applies the random offset with the given range.
-                 Check valid-offset-fns for possible values.
-                 By default its all the values of valid-offset-fns.
-
-   For example If you would like to generate datetime
-   from last 10 months to next 10 months:
-   (gen/sample (datetime {:offset-fns [clj-time.core/months]
-                          :offset-min -10
-                          :offset-max 10}))
-   =>
-   (#<DateTime 1999-11-01T00:00:00.000Z>
-    #<DateTime 1999-12-01T00:00:00.000Z>
-    #<DateTime 2000-05-01T00:00:00.000Z>
-    ....)"
-  ([]
-   (datetime {}))
-  ([{:keys [base-datetime offset-fns offset-min offset-max]
-     :or {offset-fns valid-offset-fns
-          offset-min -1000
-          offset-max 1000
-          base-datetime yr-2000}}]
-   {:pre [(<= offset-min offset-max)
-          (not-empty offset-fns)
-          (every? valid-offset-fn?
-                  offset-fns)]}
-   (gen/fmap (fn [[offset-fn offset]]
-               (->> offset
-                   offset-fn
-                   (ct/plus base-datetime)))
-             (gen/tuple (gen/elements offset-fns)
-                        (gen/large-integer* {:min offset-min
-                                             :max offset-max})))))
-)
+#?(:bb nil
+   :clj
+   (defn ^:deprecated datetime
+     "Use com.gfredericks.test.chuck.generators.clj-time/datetime instead."
+     [& args]
+     (-> 'com.gfredericks.test.chuck.generators.clj-time/datetime
+         requiring-resolve
+         (apply args)))
+   :cljs
+   (defn ^:deprecated datetime
+     "Use com.gfredericks.test.chuck.generators.clj-time/datetime instead."
+     [& args]
+     (apply ct/datetime args)))
 
 (defn- bounded-recursive-helper
   [container-gen-fn scalar-gen scalar-size max-breadth curr-height]

--- a/src/com/gfredericks/test/chuck/generators/clj_time.cljc
+++ b/src/com/gfredericks/test/chuck/generators/clj_time.cljc
@@ -1,0 +1,57 @@
+(ns com.gfredericks.test.chuck.generators.clj-time
+  (:require [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
+            [clojure.test.check.generators :as gen]))
+
+(def valid-offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months ct/years])
+
+(def ^:private valid-offset-fn? (set valid-offset-fns))
+
+(def ^:private yr-2000 (ct/date-time 2000))
+
+(defn datetime
+  "Generates datetime within given range and format.
+
+   base-datetime => By default it'll calculate the dates from year 2000.
+                    Generally this is a good idea instead of using (ct/now)
+                    since giving the same seed will generate the same output.
+                    If you would like to generate from a differnt base-datetime,
+                    Pass for example (ct/now) to use current time,
+                    Or pass a specific date-time (ct/date-time 2011 11 24)
+
+   offset-min & offset-max => The offset number range
+                              By default it is -1000 to 1000
+
+   offset-fns => List of functions which will be used with the given offset.
+                 It randomly picks one of the functions and
+                 applies the random offset with the given range.
+                 Check valid-offset-fns for possible values.
+                 By default its all the values of valid-offset-fns.
+
+   For example If you would like to generate datetime
+   from last 10 months to next 10 months:
+   (gen/sample (datetime {:offset-fns [clj-time.core/months]
+                          :offset-min -10
+                          :offset-max 10}))
+   =>
+   (#<DateTime 1999-11-01T00:00:00.000Z>
+    #<DateTime 1999-12-01T00:00:00.000Z>
+    #<DateTime 2000-05-01T00:00:00.000Z>
+    ....)"
+  ([]
+   (datetime {}))
+  ([{:keys [base-datetime offset-fns offset-min offset-max]
+     :or {offset-fns valid-offset-fns
+          offset-min -1000
+          offset-max 1000
+          base-datetime yr-2000}}]
+   {:pre [(<= offset-min offset-max)
+          (not-empty offset-fns)
+          (every? valid-offset-fn?
+                  offset-fns)]}
+   (gen/fmap (fn [[offset-fn offset]]
+               (->> offset
+                    offset-fn
+                    (ct/plus base-datetime)))
+             (gen/tuple (gen/elements offset-fns)
+                        (gen/large-integer* {:min offset-min
+                                             :max offset-max})))))

--- a/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
+++ b/test/com/gfredericks/test/chuck/clojure_test_output_test.cljc
@@ -72,7 +72,9 @@
         tc-report (edn/read-string
                     {:readers (assoc default-data-readers
                                      'error #(-> %
-                                                 (assoc ::error-tag true)))}
+                                                 (assoc ::error-tag true))
+                                     ;; Babashka outputs #object tags for namespaces, so we need to handle them
+                                     #?@(:bb ['object (constantly nil)]))}
                     out)
         error-map-msg-key #?(:clj :cause :cljs :message)]
     (testing "clojure.test reporting"

--- a/test/com/gfredericks/test/chuck/generators/clj_time_test.cljc
+++ b/test/com/gfredericks/test/chuck/generators/clj_time_test.cljc
@@ -1,0 +1,16 @@
+(ns com.gfredericks.test.chuck.generators.clj-time-test
+  (:require [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.properties :as prop]
+            #?@(:bb [] :clj [[clj-time.core :as ct]] :cljs [[cljs-time.core :as ct]])
+            #?@(:bb [] :default [[com.gfredericks.test.chuck.generators.clj-time :as gen']])))
+
+#?(:bb nil
+:default
+(defspec datetime-spec 100000
+  (prop/for-all [dt (gen'/datetime {:offset-min 0
+                                    :offset-max 100
+                                    :offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months]})]
+    (ct/within? (ct/date-time 2000)
+                (ct/date-time 2009)
+                dt)))
+)

--- a/test/com/gfredericks/test/chuck/generators_test.cljc
+++ b/test/com/gfredericks/test/chuck/generators_test.cljc
@@ -1,7 +1,6 @@
 (ns com.gfredericks.test.chuck.generators-test
   (:require [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
-            [#?(:clj clj-time.core :cljs cljs-time.core) :as ct]
             [clojure.test.check.properties :as prop]
             [com.gfredericks.test.chuck.generators :as gen']))
 
@@ -115,14 +114,6 @@
     (every? #(= (find m (key %))
                 %)
             sm)))
-
-(defspec datetime-spec 100000
-  (prop/for-all [dt (gen'/datetime {:offset-min 0
-                                    :offset-max 100
-                                    :offset-fns [ct/millis ct/seconds ct/minutes ct/hours ct/days ct/months]})]
-                (ct/within? (ct/date-time 2000)
-                            (ct/date-time 2009)
-                            dt)))
 
 (defn valid-bounded-rec-struct?
   [breadth height coll]


### PR DESCRIPTION
Closes #82 by eliding clj-time code when running under Babashka (using the `:bb` reader conditional) and the instaparse pod. Adding the instaparse-bb dep doesn't affect JVM CLJ nor CLJS environments as that library only contains `.bb` files.