### PR TITLE
Bump instaparse-bb version to v0.0.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,23 @@ jobs:
         env:
           TEST_IMPL: ${{ matrix.impl }}
       - run: lein all-my-files-should-end-with-exactly-one-newline-character but-do-they?
+  bb-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Babashka
+        uses: DeLaGuardo/setup-clojure@13
+        with:
+          bb: 1.12.198
+      - name: Test multiplier for master branch
+        if: ${{ github.event_name == 'push' }}
+        run: echo "TEST_CHECK_FACTOR=5" >> $GITHUB_ENV
+      - name: Test multiplier for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "TEST_CHECK_FACTOR=2" >> $GITHUB_ENV
+      - name: Test multiplier for cron
+        if: ${{ github.event_name == 'schedule' }}
+        run: echo "TEST_CHECK_FACTOR=10" >> $GITHUB_ENV
+      - name: Run tests with Babashka
+        run: bb run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,14 @@ jobs:
         uses: DeLaGuardo/setup-clojure@13.2
         with:
           bb: 1.12.198
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: bb-cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          restore-keys: bb-cljdeps-
       - name: Test multiplier for master branch
         if: ${{ github.event_name == 'push' }}
         run: echo "TEST_CHECK_FACTOR=5" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Babashka
-        uses: DeLaGuardo/setup-clojure@13
+        uses: DeLaGuardo/setup-clojure@13.2
         with:
           bb: 1.12.198
       - name: Test multiplier for master branch

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Please note that as of version 0.2.0, test.chuck (mostly) supports
 ClojureScript, and requires a minimum Clojure version of 1.7.0. Using
 ClojureScript requires a minimum test.check version of 0.8.0.
 
+As of version 0.2.15, test.chuck (also mostly) supports [Babashka](https://babashka.org/).
+The main unsupported feature is the time-related generators. This is because
+they use joda-time, which Babashka does not include. A java.time-based
+implementation would, in theory, work with Babashka and would be a welcome
+contribution from the community.
+
 Dependency coordinates:
 
 ``` clojure
@@ -263,6 +269,10 @@ To run with slimer.js, phantom or rhino:
 
     # replace {js-env} with phantom, slimer or rhino
     $ lein doo {js-env} test
+
+To run the tests under Babashka:
+
+    $ bb run test
 
 ## Acknowledgments
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,4 +3,4 @@
         clj-time/clj-time {:mvn/version "0.15.2"}
         com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}
         instaparse/instaparse {:mvn/version "1.4.10"}
-        io.github.babashka/instaparse-bb {:git/sha "1a7a9b8", :git/tag "v0.0.5"}}}
+        io.github.babashka/instaparse-bb {:git/sha "0d0c88e", :git/tag "v0.0.6"}}}


### PR DESCRIPTION
This version contains the final fixes that allow this to work under Babashka (and its test suite to run and pass).

It still requires a master HEAD build of Babashka itself, so not _quite_ ready for prime time, but this should be the final change needed in here for the basic functionality.